### PR TITLE
[#40] 가맹점 운영 상태 자동변경 / 테스트 코드

### DIFF
--- a/src/test/java/com/flab/foodeats/application/shop/holiday/PublicHolidayTest.java
+++ b/src/test/java/com/flab/foodeats/application/shop/holiday/PublicHolidayTest.java
@@ -82,6 +82,25 @@ class PublicHolidayTest {
 	}
 
 	@Test
+	@DisplayName("2020년 설날 / 대체공휴일 o / 대체공휴일 x")
+	void valid2020LunarNewYear() {
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200124"), is(true)); //금
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200125"), is(true)); //토
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200126"), is(true)); //일
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200127"), is(true)); //월 대체공휴일o
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200128"), is(false)); //화 대체공휴일x
+	}
+
+	@Test
+	@DisplayName("2019년 설날 / 대체공휴일 x")
+	void valid2019LunarNewYear() {
+		assertThat(new PublicHoliday().setPublicHoliday("2019").contains("20190204"), is(true)); //월
+		assertThat(new PublicHoliday().setPublicHoliday("2019").contains("20190205"), is(true)); //화
+		assertThat(new PublicHoliday().setPublicHoliday("2019").contains("20190206"), is(true)); //수
+		assertThat(new PublicHoliday().setPublicHoliday("2019").contains("20190207"), is(false)); //월 대체공휴일x
+	}
+
+	@Test
 	@DisplayName(" 2020년 삼일절 일요일")
 	void independenceMovementDay() {
 		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200301"), is(true)); //일

--- a/src/test/java/com/flab/foodeats/application/shop/holiday/PublicHolidayTest.java
+++ b/src/test/java/com/flab/foodeats/application/shop/holiday/PublicHolidayTest.java
@@ -1,0 +1,97 @@
+package com.flab.foodeats.application.shop.holiday;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PublicHolidayTest {
+
+	static Set<String> holidaysSet = new HashSet<>();
+	static int currentYear;
+	static String currentDay;
+
+
+	@BeforeEach
+	void setUp() {
+		LocalDateTime now = LocalDateTime.now();
+		currentYear = now.getYear();
+		currentDay = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+		holidaysSet = new PublicHoliday().setPublicHoliday(Integer.toString(currentYear))
+			.stream()
+			.collect(Collectors.toSet());
+	}
+
+	@Test
+	@DisplayName("오늘 확인 / calculator 메소드 자체 확인")
+	void calculator() {
+
+		boolean validCalculatorMethod = new PublicHoliday().calculator();
+		boolean validListData = holidaysSet.contains(currentDay) ? true : false;
+
+		assertThat(validCalculatorMethod, is(validListData));
+	}
+
+	@Test
+	@DisplayName("올해 어린이날")
+	void childDay() {
+		assertThat(holidaysSet.contains("20210505"), is(true)); //수
+	}
+
+	@Test
+	@DisplayName("올해 어린이날 / 대체공휴일 X")
+	void validReplacedChildDay() {
+		assertThat(holidaysSet.contains("20210506"), is(false)); //목
+	}
+
+	@Test
+	@DisplayName("올해 추석")
+	void thanksGivingDay() {
+		assertThat(holidaysSet.contains("20210920"), is(true)); //월
+		assertThat(holidaysSet.contains("20210921"), is(true)); //화
+		assertThat(holidaysSet.contains("20210922"), is(true)); //수
+	}
+
+	@Test
+	@DisplayName("올해 추석 다음날 / 대체공휴일 x")
+	void validReplacedThanksGivingDay() {
+		assertThat(holidaysSet.contains("20210923"), is(false)); //목
+	}
+
+	@Test
+	@DisplayName("올해 설날")
+	void LunarNewYear() {
+		assertThat(holidaysSet.contains("20210211"), is(true)); //목
+		assertThat(holidaysSet.contains("20210212"), is(true)); //금
+		assertThat(holidaysSet.contains("20210213"), is(true)); //토
+	}
+
+	@Test
+	@DisplayName("올해 설날 다음날 / 대체공휴일 o")
+	void validReplacedLunarNewYear() {
+		assertThat(holidaysSet.contains("20210214"), is(false)); // 일, 그냥 주말, 공휴일x, 대체공휴일x
+		assertThat(holidaysSet.contains("20210215"), is(true));  // 월, 대체공휴일
+	}
+
+	@Test
+	@DisplayName(" 2020년 삼일절 일요일")
+	void independenceMovementDay() {
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200301"), is(true)); //일
+	}
+
+	@Test
+	@DisplayName(" 2020년 삼일절 대체공휴일 월요일")
+	void validReplacedIndependenceMovementDay() {
+		assertThat(new PublicHoliday().setPublicHoliday("2020").contains("20200302"), is(true)); //월
+	}
+
+}
+


### PR DESCRIPTION
* #41  
* 공휴일 테스트 코드

가맹점 운영상태 자동변경 테스트가 아니라
**공휴일 테스트 입니다!!!** 

현재 재가 구현한 방법은 날짜를 직접 입력하지 않고 LoclaDateTime을 이용하여 연도/월/일을 now()로 직접 입력받고 있습니다.
테스트 코드를 작성하면서 테스트 코드 작성능력이 많이 부족하다는 생각이 들었습니다. 

많은 피드백 해주시면 감사하겠습니다! 
@yusok7 @f-lab-bright  