### PR TITLE
[#100] 직접 만든 세션 사용 및 레디스 저장

### DIFF
--- a/src/main/java/com/flab/foodeats/common/util/RedisSessionRepository.java
+++ b/src/main/java/com/flab/foodeats/common/util/RedisSessionRepository.java
@@ -1,0 +1,30 @@
+package com.flab.foodeats.common.util;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.flab.foodeats.common.auth.AuthInfo;
+
+@Component
+public class RedisSessionRepository {
+
+	private final RedisTemplate<String, AuthInfo> redisTemplate;
+
+	public RedisSessionRepository(
+		RedisTemplate<String, AuthInfo> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void save(String sessionId, AuthInfo authInfo) {
+		redisTemplate.opsForValue().set(sessionId, authInfo);
+	}
+
+	public AuthInfo findBySessionId(String sessionId) {
+		return redisTemplate.opsForValue().get(sessionId);
+	}
+
+	public void remove(String sessionId) {
+		redisTemplate.delete(sessionId);
+	}
+
+}

--- a/src/main/java/com/flab/foodeats/common/util/SessionManager.java
+++ b/src/main/java/com/flab/foodeats/common/util/SessionManager.java
@@ -1,0 +1,60 @@
+package com.flab.foodeats.common.util;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+
+import com.flab.foodeats.common.auth.AuthInfo;
+import com.flab.foodeats.common.response.ErrorUserCode;
+
+@Component
+public class SessionManager {
+
+	public static final String SESSION_COOKIE_NAME = "mySessionId";
+
+	private final RedisSessionRepository redisSessionRepository;
+
+	public SessionManager(RedisSessionRepository redisSessionRepository) {
+		this.redisSessionRepository = redisSessionRepository;
+	}
+
+	public void createSession(AuthInfo value, HttpServletResponse response) {
+		String sessionId = UUID.randomUUID().toString();
+		redisSessionRepository.save(sessionId, value);
+
+		Cookie mySessionCookie = new Cookie(SESSION_COOKIE_NAME, sessionId);
+		response.addCookie(mySessionCookie);
+	}
+
+	public AuthInfo getSession(HttpServletRequest request) throws Exception {
+		Cookie sessionCookie = findCookie(request, SESSION_COOKIE_NAME);
+		AuthInfo authInfo = redisSessionRepository.findBySessionId(sessionCookie.getValue());
+
+		if (authInfo == null) {
+			throw new Exception(ErrorUserCode.SESSION_NO_AUTHORIZED.getMessage());
+		}
+		return authInfo;
+	}
+
+	public void expire(HttpServletRequest request) {
+		Cookie sessionCookie = findCookie(request, SESSION_COOKIE_NAME);
+		if (sessionCookie != null) {
+			redisSessionRepository.remove(sessionCookie.getValue());
+		}
+	}
+
+	public Cookie findCookie(HttpServletRequest request, String cookieName) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+		return Arrays.stream(request.getCookies())
+			.filter(cookie -> cookie.getName().equals(cookieName))
+			.findAny()
+			.orElse(null);
+	}
+}


### PR DESCRIPTION
* #100 
* 직접 만든 세션 사용
    * 기존에 HttpSession을 사용하며 Session을 사용했지만 Session의 정확한 동작방식, 저장방식에 대한 정확한 이해가 부족했습니다.
    * 세션의 정확한 동작방식을 이해하기 위해 은수님과 함께 직접 세션을 만들어 봤습니다.
        * 세션 생성 : UUID를 사용해 임의의 랜덤값을 생성 후 쿠키의 값으로 넣어주고 응답을 보내주는 방식을 사용했습니다.
        * 세션 검색 : UUID를 사용해 값을 찾아올 수 있도록 했습니다.

* 레디스 저장 
    * 레디스 템플릿을 활용해 세션의 값을 저장할 수 있도록 했습니다.

( 코드에 적용한 것도 바로 올려놓겠습니다.)