### PR TITLE
[#104] Custom Token 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
     implementation group: 'com.ibm.icu', name: 'icu4j', version: '4.6'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'net.minidev:json-smart:2.4.7'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/foodeats/api/user/adapter/ConsumerApi.java
+++ b/src/main/java/com/flab/foodeats/api/user/adapter/ConsumerApi.java
@@ -19,10 +19,12 @@ import com.flab.foodeats.api.user.LoginUserRequest;
 import com.flab.foodeats.api.user.ModifyUserRequest;
 import com.flab.foodeats.api.user.RegisterUserRequest;
 import com.flab.foodeats.application.user.port.UserService;
+import com.flab.foodeats.common.auth.AuthConstants;
 import com.flab.foodeats.common.response.ApiResponse;
 import com.flab.foodeats.common.response.StatusCode;
 import com.flab.foodeats.common.response.SuccessUserCode;
 import com.flab.foodeats.common.util.SessionManager;
+import com.flab.foodeats.common.util.token.TokenUtils;
 import com.flab.foodeats.domain.user.UserType;
 import com.flab.foodeats.common.auth.AuthInfo;
 import com.flab.foodeats.common.auth.AuthRequired;
@@ -33,11 +35,11 @@ import com.flab.foodeats.common.auth.AuthUsed;
 public class ConsumerApi {
 
 	private final UserService userService;
-	private final SessionManager sessionManager;
+	private final TokenUtils tokenUtils;
 
-	public ConsumerApi(@Qualifier("consumerService") UserService userService, SessionManager sessionManager) {
+	public ConsumerApi(@Qualifier("consumerService") UserService userService, TokenUtils tokenUtils) {
 		this.userService = userService;
-		this.sessionManager = sessionManager;
+		this.tokenUtils = tokenUtils;
 	}
 
 	@PostMapping("/sign-up")
@@ -48,17 +50,17 @@ public class ConsumerApi {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<?> loginUserInfo(@Valid @RequestBody LoginUserRequest dto, HttpServletResponse response) {
+	public ResponseEntity<?> loginUserInfo(@Valid @RequestBody LoginUserRequest dto, HttpServletResponse response)
+		throws Exception {
 		Long consumerId = userService.login(dto.toParam());
-		ApiResponse apiResponse = ApiResponse.responseMessage(StatusCode.SUCCESS, SuccessUserCode.USER_LOGIN_SUCCESS.getMessage());
-		sessionManager.createSession(AuthInfo.consuemrOf(consumerId,dto.getUserId()), response);
+		String token = tokenUtils.createToken(AuthInfo.consuemrOf(consumerId, dto.getUserId()));
+		ApiResponse apiResponse = ApiResponse.responseData(StatusCode.SUCCESS, SuccessUserCode.USER_LOGIN_SUCCESS.getMessage(), token);
 		return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
 	}
 
 	@AuthRequired(role = UserType.CONSUMER)
 	@PostMapping("/logout")
 	public ResponseEntity<?> logoutConsumerUser(@AuthUsed AuthInfo authedLoginInfo, HttpServletRequest request) {
-		sessionManager.expire(request);
 		ApiResponse apiResponse = ApiResponse.responseMessage(StatusCode.SUCCESS, SuccessUserCode.USER_LOGOUT_SUCCESS.getMessage());
 		return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
 	}

--- a/src/main/java/com/flab/foodeats/api/user/adapter/RiderApi.java
+++ b/src/main/java/com/flab/foodeats/api/user/adapter/RiderApi.java
@@ -20,10 +20,12 @@ import com.flab.foodeats.api.user.LoginUserRequest;
 import com.flab.foodeats.api.user.ModifyUserRequest;
 import com.flab.foodeats.api.user.RegisterUserRequest;
 import com.flab.foodeats.application.user.port.UserService;
+import com.flab.foodeats.common.auth.AuthConstants;
 import com.flab.foodeats.common.response.ApiResponse;
 import com.flab.foodeats.common.response.StatusCode;
 import com.flab.foodeats.common.response.SuccessUserCode;
 import com.flab.foodeats.common.util.SessionManager;
+import com.flab.foodeats.common.util.token.TokenUtils;
 import com.flab.foodeats.domain.user.UserType;
 import com.flab.foodeats.common.auth.AuthInfo;
 import com.flab.foodeats.common.auth.AuthRequired;
@@ -34,11 +36,11 @@ import com.flab.foodeats.common.auth.AuthUsed;
 public class RiderApi {
 
 	private final UserService userService;
-	private final SessionManager sessionManager;
+	private final TokenUtils tokenUtils;
 
-	public RiderApi(@Qualifier("riderService") UserService userService, SessionManager sessionManager) {
+	public RiderApi(@Qualifier("riderService") UserService userService, TokenUtils tokenUtils) {
 		this.userService = userService;
-		this.sessionManager = sessionManager;
+		this.tokenUtils = tokenUtils;
 	}
 
 	@PostMapping("/sign-up")
@@ -49,17 +51,17 @@ public class RiderApi {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<?> loginUserInfo(@Valid @RequestBody LoginUserRequest dto, HttpServletResponse response) {
+	public ResponseEntity<?> loginUserInfo(@Valid @RequestBody LoginUserRequest dto, HttpServletResponse response)
+		throws Exception {
 		Long riderId = userService.login(dto.toParam());
-		ApiResponse apiResponse = ApiResponse.responseMessage(StatusCode.SUCCESS, SuccessUserCode.USER_LOGIN_SUCCESS.getMessage());
-		sessionManager.createSession(AuthInfo.riderOf(riderId, dto.getUserId()), response);
+		String token = tokenUtils.createToken(AuthInfo.merchantOf(riderId, dto.getUserId()));
+		ApiResponse apiResponse = ApiResponse.responseData(StatusCode.SUCCESS, SuccessUserCode.USER_LOGIN_SUCCESS.getMessage(), token);
 		return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
 	}
 
 	@AuthRequired(role = UserType.RIDER)
 	@PostMapping("/logout")
 	public ResponseEntity<?> logoutConsumerUser(@AuthUsed AuthInfo authedLoginInfo, HttpServletRequest request) {
-		sessionManager.expire(request);
 		ApiResponse apiResponse = ApiResponse.responseMessage(StatusCode.SUCCESS, SuccessUserCode.USER_LOGOUT_SUCCESS.getMessage());
 		return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
 	}

--- a/src/main/java/com/flab/foodeats/common/auth/AuthConstants.java
+++ b/src/main/java/com/flab/foodeats/common/auth/AuthConstants.java
@@ -1,0 +1,7 @@
+package com.flab.foodeats.common.auth;
+
+public class AuthConstants {
+
+	public static final String AUTH_HEADER = "Authorization";
+	public static final String TOKEN_TYPE = "BEARER";
+}

--- a/src/main/java/com/flab/foodeats/common/auth/AuthInfo.java
+++ b/src/main/java/com/flab/foodeats/common/auth/AuthInfo.java
@@ -63,6 +63,12 @@ public class AuthInfo implements Serializable {
 		this.userType = userType;
 	}
 
+	public AuthInfo(Long id, String userId, UserType userType) {
+		this.id = id;
+		this.userId = userId;
+		this.userType = userType;
+	}
+
 	@Override
 	public String toString() {
 		return "AuthInfo{" +

--- a/src/main/java/com/flab/foodeats/common/util/token/HmacEncode.java
+++ b/src/main/java/com/flab/foodeats/common/util/token/HmacEncode.java
@@ -1,0 +1,39 @@
+package com.flab.foodeats.common.util.token;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class HmacEncode {
+
+	public static final String SECRET_KEY = "TokenSecretKey";
+
+	public byte[] hmac(String secret, String data, String algorithms)
+		throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException {
+
+		//1. SecretKeySpec 클래스를 사용한 키 생성
+		SecretKeySpec secretKey = new SecretKeySpec(secret.getBytes("utf-8"), algorithms);
+
+		//2. 지정된  MAC 알고리즘을 구현하는 Mac 객체를 작성
+		Mac hasher = Mac.getInstance(algorithms);
+
+		//3. 키를 사용해 이 Mac 객체를 초기화
+		hasher.init(secretKey);
+
+		//4. 암호화 하려는 데이터의 바이트의 배열을 처리해 MAC 조작을 종료
+		return hasher.doFinal(data.getBytes());
+	}
+
+	public String hmacAndBase64(String secret, String data, String algorithms) throws Exception {
+
+		byte[] hmac = hmac(secret, data, algorithms);
+		return Base64.getEncoder().withoutPadding().encodeToString(hmac);
+	}
+}

--- a/src/main/java/com/flab/foodeats/common/util/token/TokenService.java
+++ b/src/main/java/com/flab/foodeats/common/util/token/TokenService.java
@@ -1,0 +1,14 @@
+package com.flab.foodeats.common.util.token;
+
+import com.flab.foodeats.common.auth.AuthInfo;
+
+public interface TokenService {
+
+	boolean validateHeader(String header) throws Exception;
+
+	String validateToken(String header) throws Exception;
+
+	boolean validateTokenExpiration(String token) throws Exception;
+
+	AuthInfo getAuthInfo(String token) throws Exception;
+}

--- a/src/main/java/com/flab/foodeats/common/util/token/TokenServiceImpl.java
+++ b/src/main/java/com/flab/foodeats/common/util/token/TokenServiceImpl.java
@@ -1,0 +1,84 @@
+package com.flab.foodeats.common.util.token;
+
+import static com.flab.foodeats.common.util.token.HmacEncode.*;
+
+import java.util.Base64;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.springframework.stereotype.Service;
+
+import com.flab.foodeats.common.auth.AuthConstants;
+import com.flab.foodeats.common.auth.AuthInfo;
+import com.flab.foodeats.domain.user.UserType;
+
+@Service
+public class TokenServiceImpl implements TokenService {
+
+	private final HmacEncode hmacEncode;
+
+	public TokenServiceImpl(HmacEncode hmacEncode) {
+		this.hmacEncode = hmacEncode;
+	}
+
+	@Override
+	public boolean validateHeader(String header) throws Exception {
+		if (!header.startsWith(AuthConstants.TOKEN_TYPE)) {
+			throw new Exception("Wrong Header");
+		}
+		return true;
+	}
+
+	@Override
+	public String validateToken(String header) throws Exception {
+		String token = header.substring(7);
+		String[] tokenSplit = token.split("\\.");
+
+		String tokenHeader = tokenSplit[0];    // 1. 헤더 인코딩 값
+		String tokenPayload = tokenSplit[1];   // 2. 페이로드 인코딩 값
+		String tokenSignature = tokenSplit[2]; // 3. (HEADER인코딩값.PAYLOAD인코딩값) -> 해시 -> 인코딩 된 값
+
+		String headerPayloadHash = new String(hmacEncode.hmac(SECRET_KEY, tokenHeader+"."+tokenPayload, "HmacSHA256"));
+		String signatureDecode = new String(Base64.getDecoder().decode(tokenSignature));
+
+		if (headerPayloadHash.equals(signatureDecode)) {
+			return token;
+		}
+		throw new Exception("Not validate Token");
+	}
+
+	@Override
+	public boolean validateTokenExpiration(String token) throws Exception {
+		String tokenPayloadDecode = getTokenPayloadDecode(token);
+
+		JSONParser parser = new JSONParser();
+		JSONObject parse = (JSONObject)parser.parse(tokenPayloadDecode);
+
+		Long expiration = Long.valueOf((String)parse.get("exp"));
+		if (System.currentTimeMillis() > expiration) {
+			throw new Exception("Not validate Token");
+		}
+		return true;
+	}
+
+	@Override
+	public AuthInfo getAuthInfo(String token) throws Exception {
+		String tokenPayloadDecode = getTokenPayloadDecode(token);
+
+		JSONParser parser = new JSONParser();
+		JSONObject parse = (JSONObject)parser.parse(tokenPayloadDecode);
+
+		long id = Long.valueOf((String)parse.get("id"));
+		String userId = (String)parse.get("userId");
+		UserType userType = UserType.valueOf((String)parse.get("userType"));
+
+		return new AuthInfo(id, userId, userType);
+	}
+
+	private String getTokenPayloadDecode(String token) {
+		String[] tokenSplit = token.split("\\.");
+		String tokenPayload = tokenSplit[1];
+
+		return new String(Base64.getDecoder().decode(tokenPayload));
+	}
+}

--- a/src/main/java/com/flab/foodeats/common/util/token/TokenUtils.java
+++ b/src/main/java/com/flab/foodeats/common/util/token/TokenUtils.java
@@ -1,0 +1,61 @@
+package com.flab.foodeats.common.util.token;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minidev.json.JSONObject;
+import org.springframework.stereotype.Component;
+import com.flab.foodeats.common.auth.AuthInfo;
+
+@Component
+public class TokenUtils {
+
+	private final HmacEncode hmacEncode;
+
+	public TokenUtils(HmacEncode hmacEncode) {
+		this.hmacEncode = hmacEncode;
+	}
+
+	public String createToken(AuthInfo authInfo) throws Exception {
+
+		String encodedheader = createHeader();
+		String encodedpayload = createPayload(authInfo);
+		String signature = encodedheader + "." + encodedpayload;
+
+		String encodedSignature = hmacEncode.hmacAndBase64(HmacEncode.SECRET_KEY, signature, "HmacSHA256");
+		return encodedheader + "." + encodedpayload + "." + encodedSignature;
+	}
+
+	public String createHeader() {
+		Map<String, String> header = new HashMap<>(2);
+		header.put("typ", "JWT");
+		header.put("alg", "HS256");
+
+		JSONObject jsonObject = new JSONObject(header);
+		String headerToString = String.valueOf(jsonObject);
+		String encodedHeader = Base64.getEncoder()
+			.withoutPadding()
+			.encodeToString(headerToString.getBytes());
+		return encodedHeader;
+	}
+
+	private String createPayload(AuthInfo authInfo) {
+		Map<String, String> payload = new HashMap<>(7);
+
+		payload.put("iss", "flab.com"); // 토큰 발급자
+		payload.put("sub", "AuthorizationToken"); // 토큰 제목
+		payload.put("iat", String.valueOf(System.currentTimeMillis())); // 토큰이 발급된 시간
+		payload.put("exp", String.valueOf(System.currentTimeMillis() + 30 * 60000)); // 토큰 만료시간 30분
+		payload.put("id", String.valueOf(authInfo.getId()));
+		payload.put("userId", authInfo.getUserId());
+		payload.put("userType", String.valueOf(authInfo.getUserType()));
+
+		JSONObject jsonObject = new JSONObject(payload);
+		String payloadToString = String.valueOf(jsonObject);
+		String encodedPayload = Base64.getEncoder()
+			.withoutPadding()
+			.encodeToString(payloadToString.getBytes());
+		return encodedPayload;
+	}
+}


### PR DESCRIPTION
* #104 

* Claim 기반의 토큰인 JWT를 직접 구현해봤습니다.
    * 토큰의 동작원리 이해를 목표

* 토큰의 생성
    * 사용자가 로그인 요청 시, 올바른 사용자일 경우 서버에서 token을 발급합니다.
    * 사용자는 인증이 필요한 api요청 시, Http Header에 Authorization을 key 값으로 token을 함께 보냅니다.

* 토큰 구성
    * 토큰은 JWT토큰을 기반으로 만들었습니다.  
    * Header.Payload.Signature

    * Header
        * Token의 타입과 Signature에서 사용되는 Hash Algorithm 값이 들어있습니다.

    * Payload
        * 총 7개의 값이 들어가도록 설정했습니다.
        * iss : 토큰발급자, sub : 토큰제목, iat : 토큰 발생 시점, exp : 토큰 만료시간, id : user의 고유 id(long값), userId : 사용자 ID, userType : 사용자 타입

    * Signature
        * Header의 Base64로 인코딩 된 값과, Payload의 인코딩 된 값을 "." 으로 합치기
        * 합친 값을 Header에서 정의한 해시 알고리즘과 Secret Key로 암호화
        * 해시 된 값을 Base64로 인코딩
        * 최종적으로 이 값을 Signature에 담았습니다.

* 토큰의 검증
    * Header + "." +Payload 을 Secret Key와 해시암호화 하여 Signature를 Base64 디코딩한 값과 일치하는지 확인
        * 위의 절차를 통과하면 Payload값 사용
    * Payload의 토큰 만료시간(30분) 지났는지 확인

* Custom 토큰 디코딩
![내가만든토큰](https://user-images.githubusercontent.com/53485840/133930997-9079392d-9c1a-4236-9f66-b4a314927cd2.PNG)

